### PR TITLE
Add method signature to PHPDoc of the Feature facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All Notable changes to `laravel-feature` will be documented in this file.
 
 Updates follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [Unreleased]
+
+### Added
+- Add method signature to PHPDoc of the Feature facade
+
 ## 0.1.0 - 2016-12-18
 
 ### Added

--- a/src/Facade/Feature.php
+++ b/src/Facade/Feature.php
@@ -5,6 +5,17 @@ namespace LaravelFeature\Facade;
 use LaravelFeature\Domain\FeatureManager;
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static void add($featureName, $isEnabled)
+ * @method static void remove($featureName)
+ * @method static void rename($featureOldName, $featureNewName)
+ * @method static void enable($featureName)
+ * @method static void disable($featureName)
+ * @method static void isEnabled($featureName)
+ * @method static bool enableFor($featureName, \LaravelFeature\Featurable\FeaturableInterface $featurable)
+ * @method static void disableFor($featureName, \LaravelFeature\Featurable\FeaturableInterface $featurable)
+ * @method static bool isEnabledFor($featureName, \LaravelFeature\Featurable\FeaturableInterface $featurable)
+ */
 class Feature extends Facade
 {
     /**


### PR DESCRIPTION
## Description

Add method signature of the methods provided by the FeatureManager that are exposed via the Feature facade.

## Motivation and context

Adding the method signatures to support type hinting for the facade in the IDE. This way the developer knows the method that are available via the facade without peeking in the FeatureManager class.

## How has this been tested?

Verified in PHPStorm the supported methods are completed on the facade.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.