### PR TITLE
Fix service provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.idea

--- a/src/Provider/FeatureServiceProvider.php
+++ b/src/Provider/FeatureServiceProvider.php
@@ -21,6 +21,9 @@ class FeatureServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../Config/features.php' => config_path('features.php'),
         ]);
+
+        $this->registerBladeDirectives();
+        $this->registerConsoleCommand();
     }
 
     /**
@@ -37,9 +40,6 @@ class FeatureServiceProvider extends ServiceProvider
         $this->app->bind(FeatureRepositoryInterface::class, function () use ($config) {
             return app()->make($config->get('features.repository'));
         });
-
-        $this->registerBladeDirectives();
-        $this->registerConsoleCommand();
     }
 
     private function registerBladeDirectives()


### PR DESCRIPTION
## Description
fixes for this: https://github.com/laravel/framework/pull/25497
by moving the register methods for blade directives and console commands to the `boot` method of the service provider.

## How has this been tested?
Copied modified library into my TCP local and loaded dashboard. Dev-only menu items (behind feature flags) were shown.

## Next steps
Use this lib in TCP, and remove the original