### PR TITLE
Laravel 9 and PHP 8.1 Support with CI

### DIFF
--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -8,7 +8,7 @@ on:
         tags:
             - '*'
     pull_request:
-        branches: [ production ]
+        branches: [ master ]
 
     workflow_dispatch:
 

--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -1,0 +1,143 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - production
+            - dev
+        tags:
+            - '*'
+    pull_request:
+        branches: [ production ]
+
+    workflow_dispatch:
+
+jobs:
+    composer:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+
+            - name: Setup PHP with composer v2
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+                  tools: composer:v2
+
+            - name: Install composer packages
+              run: |
+                  php -v
+                  composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
+
+            - name: Compress composer folder
+              run: tar -czvf composer.tgz vendor/
+
+            - name: Upload composer assets
+              uses: actions/upload-artifact@v2
+              with:
+                  name: composer
+                  path: composer.tgz
+                  retention-days: 3
+
+    phpcs:
+        strategy:
+            matrix:
+                version: ['7.4', '8.1']
+        runs-on: ubuntu-latest
+        needs: [composer]
+
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Download composer artifacts
+              uses: actions/download-artifact@v2
+              with:
+                  name: composer
+
+            - name: Unpack composer artifacts
+              run: |
+                  tar xvfz composer.tgz
+
+            - name: Setup PHP with composer v2
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.version }}
+                  tools: composer:v2
+
+            - name: Execute PHP_CodeSniffer
+              run: |
+                  php -v
+                  cp .env.testing .env
+                  composer check-style
+
+    phpunit:
+        strategy:
+            matrix:
+                version: ['7.4', '8.1']
+        runs-on: ubuntu-latest
+        needs: [composer]
+
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Download composer artifacts
+              uses: actions/download-artifact@v2
+              with:
+                  name: composer
+
+            - name: Unpack composer artifacts
+              run: |
+                  tar xvfz composer.tgz
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.version }}
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, intl, exif, iconv
+                  coverage: xdebug
+
+            - name: Execute tests
+              run: |
+                  cp .env.testing .env
+                  php -v
+                  ./vendor/phpunit/phpunit/phpunit --version
+                  ./vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.xml
+#                  export CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}
+#                  bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
+
+#            - name: Upload code coverage
+#              run: |
+#                  export CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}
+#                  bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
+
+            - name: Upload log artifacts
+              uses: actions/upload-artifact@v2
+              with:
+                  name: logs
+                  path: ~/storage/logs
+                  retention-days: 3
+
+    package-security-checker:
+        runs-on: ubuntu-latest
+        needs: [composer]
+
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+
+            - name: Install security-checker
+              run: |
+                  test -d local-php-security-checker || curl -L https://github.com/fabpot/local-php-security-checker/releases/download/v1.2.0/local-php-security-checker_1.2.0_linux_amd64 --output local-php-security-checker
+                  chmod +x local-php-security-checker
+                  ./local-php-security-checker

--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -78,13 +78,6 @@ jobs:
 #                  export CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }}
 #                  bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
 
-            - name: Upload log artifacts
-              uses: actions/upload-artifact@v2
-              with:
-                  name: logs
-                  path: ~/storage/logs
-                  retention-days: 3
-
     package-security-checker:
         runs-on: ubuntu-latest
 

--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -3,7 +3,7 @@ name: CI
 on:
     push:
         branches:
-            - production
+            - master
             - dev
         tags:
             - '*'

--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -13,40 +13,11 @@ on:
     workflow_dispatch:
 
 jobs:
-    composer:
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Checkout the repository
-              uses: actions/checkout@v2
-
-            - name: Setup PHP with composer v2
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-                  tools: composer:v2
-
-            - name: Install composer packages
-              run: |
-                  php -v
-                  composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
-
-            - name: Compress composer folder
-              run: tar -czvf composer.tgz vendor/
-
-            - name: Upload composer assets
-              uses: actions/upload-artifact@v2
-              with:
-                  name: composer
-                  path: composer.tgz
-                  retention-days: 3
-
     phpcs:
         strategy:
             matrix:
                 version: ['7.4', '8.1']
         runs-on: ubuntu-latest
-        needs: [composer]
 
         steps:
             - name: Checkout the repository
@@ -54,20 +25,16 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Download composer artifacts
-              uses: actions/download-artifact@v2
-              with:
-                  name: composer
-
-            - name: Unpack composer artifacts
-              run: |
-                  tar xvfz composer.tgz
-
             - name: Setup PHP with composer v2
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.version }}
                   tools: composer:v2
+
+            - name: Install composer packages
+              run: |
+                  php -v
+                  composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
 
             - name: Execute PHP_CodeSniffer
               run: |
@@ -79,7 +46,6 @@ jobs:
             matrix:
                 version: ['7.4', '8.1']
         runs-on: ubuntu-latest
-        needs: [composer]
 
         steps:
             - name: Checkout the repository
@@ -87,21 +53,17 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Download composer artifacts
-              uses: actions/download-artifact@v2
-              with:
-                  name: composer
-
-            - name: Unpack composer artifacts
-              run: |
-                  tar xvfz composer.tgz
-
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.version }}
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, intl, exif, iconv
                   coverage: xdebug
+
+            - name: Install composer packages
+              run: |
+                  php -v
+                  composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
 
             - name: Execute tests
               run: |
@@ -125,7 +87,6 @@ jobs:
 
     package-security-checker:
         runs-on: ubuntu-latest
-        needs: [composer]
 
         steps:
             - name: Checkout the repository
@@ -133,6 +94,11 @@ jobs:
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
+
+            - name: Install composer packages
+              run: |
+                  php -v
+                  composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
 
             - name: Install security-checker
               run: |

--- a/.github/workflows/.github-actions.yml
+++ b/.github/workflows/.github-actions.yml
@@ -72,7 +72,6 @@ jobs:
             - name: Execute PHP_CodeSniffer
               run: |
                   php -v
-                  cp .env.testing .env
                   composer check-style
 
     phpunit:
@@ -106,7 +105,6 @@ jobs:
 
             - name: Execute tests
               run: |
-                  cp .env.testing .env
                   php -v
                   ./vendor/phpunit/phpunit/phpunit --version
                   ./vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php" : "^7.4",
-        "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0"
+        "php" : "^7.4|^8.1",
+        "illuminate/database": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/database": "^6.0",
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^8.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "orchestra/database": "^6.0|^7.0",
+        "orchestra/testbench": "^6.0|^7.0",
+        "phpunit/phpunit": "^8.0|^9.0",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,23 +17,4 @@
             <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">src/Facade</directory>
-                <directory suffix=".php">src/Featurable</directory>
-                <directory suffix=".php">src/Provider</directory>
-                <directory suffix=".php">src/Config</directory>
-                <directory suffix=".php">src/Console</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
## Description

- Composer.json updated to support both Laravel 8/PHP 7.4 and Laravel 9/PHP 8.1 so it can be tagged as a non breaking change (change to just support Laravel 9 and 8.1 if you want to release on a 3.0.0 tag).
- GitHub Actions workflow added. https://github.com/clnt/laravel-feature/actions

## Motivation and context

Package does not install on a Laravel 9 install with PHP 8.1 due to composer restraints.

## How has this been tested?

New GitHub Actions CI workflow added which runs a matrix running PHPUnit on both PHP 7.4 and PHP 8.1 (travis could be removed)
Left the code I use for codecov commented out if you wish to use it over scrutinizer otherwise action step will need updating to use.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

